### PR TITLE
Update behaviour contract for ALL keyword

### DIFF
--- a/src/dqe_idx.erl
+++ b/src/dqe_idx.erl
@@ -29,13 +29,14 @@
 -type tags() :: [{Namespace::namespace(), TagName::tag_name(),
                   Value::tag_value()}].
 
+-type opt_metric() :: [metric()] | undefined.
 
 -type where() :: {'=',  tag(), tag_value()} |
                  {'and', where(), where()} |
                  {'or', where(), where()}.
 
--type lqry() :: {in, collection(), [metric()]} |
-                {in, collection(), [metric()], where()}.
+-type lqry() :: {in, collection(), opt_metric()} |
+                {in, collection(), opt_metric(), where()}.
 
 -type group_by_field() :: binary().
 


### PR DESCRIPTION
This PR is the first step in implementing the proposal https://github.com/dalmatinerdb/dalmatinerdb/issues/75

There were three alternatives to encoding this keyword in the callback:

1) Pass the atom `undefined` in place of a metric
2) Create a new callback function  `lookup_all`
3) Tagging the lookup query tuple as `all` instead of `in`.

I have opted for the 1st option in this PR, as it aligns closely to the spec proposed in https://github.com/dalmatinerdb/dqe_idx/issues/7
