### PR TITLE
Support listing metrics by prefix and depth

### DIFF
--- a/src/dqe_idx.erl
+++ b/src/dqe_idx.erl
@@ -68,9 +68,9 @@
     {ok, metric()} |
     {error, Error::term()}.
 
--callback metrics(Collection::collection(), Prefix::[metric()],
+-callback metrics(Collection::collection(), Prefix::metric(),
                   Depth::pos_integer()) ->
-    {ok, [metric()]} |
+    {ok, metric()} |
     {error, Error::term()}.
 
 -callback namespaces(Collection::collection()) ->
@@ -234,12 +234,12 @@ metrics(Collection) ->
 %% For example:
 %% metrics(<<"collection">>, [], 1) -> [<<"base">>].
 %% metrics(<<"collection">>, [<<"base">>], 1) -> [<<"cpu">>].
-%% metrics(<<"collection">>, [], 2) -> [[<<"base">>.<<"cpu">>]].
+%% metrics(<<"collection">>, [], 2) -> [[<<"base">>,<<"cpu">>]].
 %% @end
 %%--------------------------------------------------------------------
--spec metrics(Collection::collection(), Prefix::[metric()],
+-spec metrics(Collection::collection(), Prefix::metric(),
               Depth::pos_integer()) ->
-                    {ok, [Metric::metric()]} |
+                    {ok, Metric::metric()} |
                     {error, Error::term()}.
 metrics(Collection, Prefix, Depth) ->
     Mod = idx_module(),

--- a/src/dqe_idx.erl
+++ b/src/dqe_idx.erl
@@ -68,7 +68,7 @@
     {ok, metric()} |
     {error, Error::term()}.
 
--callback metrics(Collection::collection(), Prefix::metric(),
+-callback metrics(Collection::collection(), Prefix::[metric()],
                   Depth::pos_integer()) ->
     {ok, [metric()]} |
     {error, Error::term()}.
@@ -232,15 +232,12 @@ metrics(Collection) ->
 %% by the given probe `Prefix', which can also be empty.
 %%
 %% For example:
-%% metrics(<<"collection">>, <<>>, 1) -> [<<"base">>].
-%% metrics(<<"collection">>, <<"base">>, 1) -> [<<"cpu">>].
-%% metrics(<<"collection">>, <<>>, 2) -> [[<<"base">>.<<"cpu">>]].
-%%
-%% Actual results are binary-encoded in `dproto' encoding.
+%% metrics(<<"collection">>, [], 1) -> [<<"base">>].
+%% metrics(<<"collection">>, [<<"base">>], 1) -> [<<"cpu">>].
+%% metrics(<<"collection">>, [], 2) -> [[<<"base">>.<<"cpu">>]].
 %% @end
 %%--------------------------------------------------------------------
--spec metrics(Collection::collection(),
-              Prefix::metric(),
+-spec metrics(Collection::collection(), Prefix::[metric()],
               Depth::pos_integer()) ->
                     {ok, [Metric::metric()]} |
                     {error, Error::term()}.

--- a/src/dqe_idx.erl
+++ b/src/dqe_idx.erl
@@ -12,8 +12,8 @@
 %% API exports
 -export([init/0,
          lookup/1, lookup/2, lookup_tags/1,
-         collections/0, metrics/1, namespaces/1, namespaces/2,
-         tags/2, tags/3, values/3, values/4, expand/2, metric_variants/2,
+         collections/0, metrics/1, metrics/3, namespaces/1, namespaces/2,
+         tags/2, tags/3, values/3, values/4, expand/2,
          add/4, add/5, update/5,
          delete/4, delete/5]).
 
@@ -68,6 +68,11 @@
     {ok, metric()} |
     {error, Error::term()}.
 
+-callback metrics(Collection::collection(), Prefix::[metric()],
+                  Depth::pos_integer()) ->
+    {ok, [metric()]} |
+    {error, Error::term()}.
+
 -callback namespaces(Collection::collection()) ->
     {ok, [namespace()]} |
     {error, Error::term()}.
@@ -97,10 +102,6 @@
 
 -callback expand(Bucket::bucket(), [glob_metric()]) ->
     {ok, {bucket(), metric()}} |
-    {error, Error::term()}.
-
--callback metric_variants(Collection::collection(), Prefix::metric()) ->
-    {ok, metric()} |
     {error, Error::term()}.
 
 -callback add(Collection::collection(),
@@ -227,6 +228,25 @@ metrics(Collection) ->
 
 %%--------------------------------------------------------------------
 %% @doc
+%% Returns a list of metric path suffixes of `Depth' that are prefixed
+%% by the given probe `Prefix', which can also be empty.
+%%
+%% For example:
+%% metrics(<<"collection">>, [], 1) -> [<<"base">>].
+%% metrics(<<"collection">>, [<<"base">>], 1) -> [<<"cpu">>].
+%% metrics(<<"collection">>, [], 2) -> [[<<"base">>.<<"cpu">>]].
+%% @end
+%%--------------------------------------------------------------------
+-spec metrics(Collection::collection(), Prefix::[metric()],
+              Depth::pos_integer()) ->
+                    {ok, [Metric::metric()]} |
+                    {error, Error::term()}.
+metrics(Collection, Prefix, Depth) ->
+    Mod = idx_module(),
+    Mod:metrics(Collection, Prefix, Depth).
+
+%%--------------------------------------------------------------------
+%% @doc
 %% Lists all namespaces in a collection, across all metrics.
 %% @end
 %%--------------------------------------------------------------------
@@ -320,24 +340,6 @@ values(Collection, Metric, Namespace, Tag) ->
 expand(B, Gs) ->
     Mod = idx_module(),
     Mod:expand(B, Gs).
-
-%%--------------------------------------------------------------------
-%% @doc
-%% Returns a list of metric path suffixes of depth one that are prefixed
-%% by the given probe `Prefix', which can also be empty.
-%%
-%% For example:
-%% metric_variants(<<"collection">>, []) -> [<<"base">>].
-%% metric_variants(<<"collection">>, [<<"base">>]) -> [<<"cpu">>, <<"disk">>].
-%% @end
-%%--------------------------------------------------------------------
-
--spec metric_variants(Collection::collection(), Prefix::metric()) ->
-                    {ok, Metric::metric()} |
-                    {error, Error::term()}.
-metric_variants(Collection, Prefix) ->
-    Mod = idx_module(),
-    Mod:metric_variants(Collection, Prefix).
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/src/dqe_idx.erl
+++ b/src/dqe_idx.erl
@@ -65,12 +65,12 @@
     {error, Error::term()}.
 
 -callback metrics(Collection::collection()) ->
-    {ok, metric()} |
+    {ok, [metric()]} |
     {error, Error::term()}.
 
 -callback metrics(Collection::collection(), Prefix::metric(),
                   Depth::pos_integer()) ->
-    {ok, metric()} |
+    {ok, [metric()]} |
     {error, Error::term()}.
 
 -callback namespaces(Collection::collection()) ->
@@ -101,7 +101,7 @@
     {error, Error::term()}.
 
 -callback expand(Bucket::bucket(), [glob_metric()]) ->
-    {ok, {bucket(), metric()}} |
+    {ok, {bucket(), [metric()]}} |
     {error, Error::term()}.
 
 -callback add(Collection::collection(),
@@ -220,7 +220,7 @@ collections() ->
 %%--------------------------------------------------------------------
 
 -spec metrics(Collection::collection()) ->
-                     {ok, metric()} |
+                     {ok, [metric()]} |
                      {error, Error::term()}.
 metrics(Collection) ->
     Mod = idx_module(),
@@ -239,7 +239,7 @@ metrics(Collection) ->
 %%--------------------------------------------------------------------
 -spec metrics(Collection::collection(), Prefix::metric(),
               Depth::pos_integer()) ->
-                    {ok, Metric::metric()} |
+                    {ok, [metric()]} |
                     {error, Error::term()}.
 metrics(Collection, Prefix, Depth) ->
     Mod = idx_module(),
@@ -335,7 +335,7 @@ values(Collection, Metric, Namespace, Tag) ->
 %%--------------------------------------------------------------------
 
 -spec expand(bucket(), [glob_metric()]) ->
-                    {ok, {bucket(), metric()}} |
+                    {ok, {bucket(), [metric()]}} |
                     {error, Error::term()}.
 expand(B, Gs) ->
     Mod = idx_module(),

--- a/src/dqe_idx.erl
+++ b/src/dqe_idx.erl
@@ -68,7 +68,7 @@
     {ok, metric()} |
     {error, Error::term()}.
 
--callback metrics(Collection::collection(), Prefix::[metric()],
+-callback metrics(Collection::collection(), Prefix::metric(),
                   Depth::pos_integer()) ->
     {ok, [metric()]} |
     {error, Error::term()}.
@@ -232,12 +232,15 @@ metrics(Collection) ->
 %% by the given probe `Prefix', which can also be empty.
 %%
 %% For example:
-%% metrics(<<"collection">>, [], 1) -> [<<"base">>].
-%% metrics(<<"collection">>, [<<"base">>], 1) -> [<<"cpu">>].
-%% metrics(<<"collection">>, [], 2) -> [[<<"base">>.<<"cpu">>]].
+%% metrics(<<"collection">>, <<>>, 1) -> [<<"base">>].
+%% metrics(<<"collection">>, <<"base">>, 1) -> [<<"cpu">>].
+%% metrics(<<"collection">>, <<>>, 2) -> [[<<"base">>.<<"cpu">>]].
+%%
+%% Actual results are binary-encoded in `dproto' encoding.
 %% @end
 %%--------------------------------------------------------------------
--spec metrics(Collection::collection(), Prefix::[metric()],
+-spec metrics(Collection::collection(),
+              Prefix::metric(),
               Depth::pos_integer()) ->
                     {ok, [Metric::metric()]} |
                     {error, Error::term()}.


### PR DESCRIPTION
Propose a rename the function from `metric_variants` to `metrics`, as there is symmetry to the existing `metrics/1` function.  
From the dalmatiner-frontend perspective, it may allow a more concise resource location eg:
`http://localhost:8080/collections/7c/metrics/aW5mbHV4ZGIucHJvY2Vzc2Vz`

The `depth` argument allows the client to configure the depth for the search by prefix.

Example: depth 1, prefix <<"base">>

```
{ok,[[<<"count">>],
     [<<"cpu">>],
     [<<"ctx-switch">>],
     ...
     [<<"swap">>],
     [<<"uptime">>],
     [<<"vmem">>]]}
```

Example: depth 3, prefix <<"base">>

```
{ok,[[<<"count">>],
     [<<"cpu">>],
     [<<"cpu">>,<<"0">>,<<"guest">>],
     [<<"cpu">>,<<"0">>,<<"guest_nice">>],
     [<<"cpu">>,<<"0">>,<<"idle">>],
     [<<"cpu">>,<<"0">>,<<"iowait">>],
    ...
     [<<"cpu">>,<<"1">>,<<"steal">>],
     [<<"cpu">>,<<"1">>,<<"system">>],
     [<<"cpu">>,<<"1">>,<<"user">>],
     [<<"cpu">>,<<"10">>,<<"idle">>]]}
```

Note that results above are decoded from dproto metric encoding.
